### PR TITLE
Change separator to `,`

### DIFF
--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -179,7 +179,7 @@ The following example shows a request for a JPEG file with the urgency set to
 :scheme = https
 :authority = example.net
 :path = /image.jpg
-priority = urgency=non-blocking; progressive=yes
+priority = urgency=non-blocking, progressive=yes
 ~~~
 
 ## Merging Client- and Server-Driven Directives {#merging}
@@ -200,7 +200,7 @@ For example, when the client sends an HTTP request with
 :scheme = https
 :authority = example.net
 :path = /image.jpg
-priority = urgency=non-blocking; progressive=yes
+priority = urgency=non-blocking, progressive=yes
 ~~~
 
 and the origin responds with


### PR DESCRIPTION
I think we need to discuss what the separator is.

ABNF uses `1#priority-directive`, meaning that the separator is `,`. In #6, the examples have been changed to `;` (I thought we were changing examples using `;` to `,`).

My preference is to use `,`, because I think of Priority header to be analogous to Cache-Control header or other header fields using the `1#` rule. I am not sure if there is any reason to use a different rule for the Priority header.

@LPardue WDYT?