### PR TITLE
restructure the text related to H2 coexistence. Make SETTINGS usage …

### DIFF
--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -203,8 +203,8 @@ parameter.
 
 Standard HTTP/2 ({{!RFC7540}}) endpoints use frame-based prioritization, whereby
 a client sends priority information in dedicated fields present in HEADERS and
-PRIORITY frames. A client may instead choose to use header-based prioritization
-as specified in this document.
+PRIORITY frames. A client might instead choose to use header-based
+prioritization as specified in this document.
 
 ## The SETTINGS_HEADER_BASED_PRIORITY SETTINGS Parameter
 


### PR DESCRIPTION
…clearer.

To start, we don't use the terms header-based and frame-based until late in the document. So I pulled that straight up into the introduction.

The H2 coexistence section then builds on that earlier definition. Promoted definition of the SETTING to a subsection for more visibility and got stricter on the rules for using it.

Bottom-line: the parameter is a recommended useful signal for a client to use when it wants to use header-based prioritisation. However, no negotiation is required.