### PR TITLE
explain server overrides using urgency

### DIFF
--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -171,7 +171,7 @@ priority = urgency=non-blocking, progressive=?1
 It is not always the case that the client has the best understanding of how the
 HTTP responses deserve to be prioritized.  For example, use of an HTML document
 might depend heavily on one of the inline images.  Existence of such dependency
-is typcially best known by the person that administers the document.
+is typically best known to the person that administers the document.
 
 By using the "Priority" response header, a server can override the
 prioritization hints provided by the client.  When used, the parameters found

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -168,14 +168,14 @@ priority = urgency=non-blocking, progressive=?1
 
 # Merging Client- and Server-Driven Parameters {#merging}
 
-It is not always the case that the client has the best view of how the HTTP
-responses should be prioritized.  For example, whether a JPEG image should be
-served progressively by the server depends on the structure of that image file
-- a property only known to the server.
+It is not always the case that the client has the best understanding of how the
+HTTP responses deserve to be prioritized.  For example, use of an HTML document
+might depend heavily on one of the inline images.  Existence of such dependency
+is typcially best known by the person that administers the document.
 
-Therefore, a server is permitted to send a "Priority" response header field.
-When used, the parameters found in this response header field override those
-specified by the client.
+By using the "Priority" response header, a server can override the
+prioritization hints provided by the client.  When used, the parameters found
+in the response header field overrides those specified by the client.
 
 For example, when the client sends an HTTP request with
 
@@ -183,7 +183,7 @@ For example, when the client sends an HTTP request with
 :method = GET
 :scheme = https
 :authority = example.net
-:path = /image.jpg
+:path = /menu.png
 priority = urgency=non-blocking, progressive=?1
 ~~~
 
@@ -191,14 +191,14 @@ and the origin responds with
 
 ~~~ example
 :status = 200
-content-type = image/jpeg
-priority = progressive=?0
+content-type = image/png
+priority = urgency=document
 ~~~
 
-the intermediary's view of the progressiveness of the response becomes negative,
-because the server-provided value overrides that provided by the client.  The
-urgency is deemed as `non-blocking`, because the server did not specify the
-parameter.
+the intermediary's view of the urgency of the response is promoted from
+`non-blocking` to `document`, because the server-provided value overrides that
+provided by the client.  The progressiveness of the response continues to be
+deemed as true, because the server did not specify the `progressive` parameter.
 
 # Coexistence with HTTP/2 Priorities {#coexistence}
 

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -170,8 +170,8 @@ priority = urgency=non-blocking, progressive=?1
 
 It is not always the case that the client has the best understanding of how the
 HTTP responses deserve to be prioritized.  For example, use of an HTML document
-might depend heavily on one of the inline images.  Existence of such dependencies
-is typically best known to the person that administers the document.
+might depend heavily on one of the inline images.  Existence of such
+dependencies is typically best known to the server.
 
 By using the "Priority" response header, a server can override the
 prioritization hints provided by the client.  When used, the parameters found

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -195,10 +195,10 @@ content-type = image/png
 priority = urgency=document
 ~~~
 
-the intermediary's view of the urgency of the response is promoted from
-`non-blocking` to `document`, because the server-provided value overrides that
-provided by the client.  The progressiveness of the response continues to be
-deemed as true, because the server did not specify the `progressive` parameter.
+the intermediary's understanding of the urgency is promoted from `non-blocking`
+to `document`, because the server-provided value overrides that provided by the
+client.  The progressiveness continues to be `1`, the value specified by the
+client, as the server did not specify the `progressive` parameter.
 
 # Coexistence with HTTP/2 Priorities {#coexistence}
 

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -170,7 +170,7 @@ priority = urgency=non-blocking, progressive=?1
 
 It is not always the case that the client has the best understanding of how the
 HTTP responses deserve to be prioritized.  For example, use of an HTML document
-might depend heavily on one of the inline images.  Existence of such dependency
+might depend heavily on one of the inline images.  Existence of such dependencies
 is typically best known to the person that administers the document.
 
 By using the "Priority" response header, a server can override the


### PR DESCRIPTION
Current text explains server override by using the progressive parameter as the example.

However, it seems to be confusing (see https://lists.w3.org/Archives/Public/ietf-http-wg/2019JulSep/0042.html).

It would be better to talk about changing urgency rather than progressiveness, because the former would be the common use-case and has bigger impact on user experience.