### PR TITLE
Expand collaboration and contrast to H2

### DIFF
--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -236,10 +236,10 @@ priority = urgency=3, progressive=?1
 # Prioritization Process and Lifecycle
 
 HTTP/2 alludes to a prioritization process and does not specify many details
-about it. This might go some way to explain the different perspectives about
-prioritization that arise from different operators and use cases. The design
-also mixes concerns about prioritization between requests, streams and
-connections.
+about it. The prioritization scheme mixes concerns about requests, streams and
+connections, which complicates understanding. These factors might go some way to
+explain the different perspectives about prioritization that arise from
+different operators and use cases.
 
 HTTP/2's frame-based prioritization places an emphasis on the client's role in
 determining the priority of a response. {{?RFC7540}} Section 5.3 describes
@@ -265,7 +265,7 @@ generation, the server can possibly determine that the client's predicted
 prioritization was incorrect (perhaps sub-optimal) for how the selected
 representation will be used. An HTTP/2 server might use this information,
 together with other inputs, to send the response at a different effective
-priority than the client suggested. However, it has no explicit means on which
+priority than the client suggested. However, it has no explicit means by which
 to present such a finding to the client.
 
 The frame-based prioritization process weakens further when intermediaries are
@@ -277,12 +277,12 @@ A collaborative model is presented that attempts to abstract priority and
 collaboration from concerns about HTTP version and active connections.
 
 Resources have an initial priority that begins with a neutral value. Requests
-and responses permit collaborative changes to the resources initial priority
+and responses permit collaborative changes to the resource's initial priority
 information. A client attaches suggested priority information to the request,
 omission activates a default priority. A server can (if supported) attach
 priority information to the response, omission might be an acceptance of the
-client offer or or implicit ignore. Once a request or response is in flight, an
-endpoint cannot modify the initial priority, further changes are classed as
+client offer or an implicit ignore. Once a request or response is in flight, an
+endpoint cannot modify the initial priority, any further change is classed as a
 reprioritization that requires a non-request or non-response carriage mechanism
 (e.g. a frame).
 
@@ -291,13 +291,13 @@ prioritization signal for servers.
 
 ## Explicit Client and Server Collaboration {#collaboration}
 
-The "Priority" header field can be attached to responses in order to provide an
-explicit signal that allows servers collaborate to collaborate on the
-prioritization process. A server sends new priority parameter values or confirms
-the client suggestion. This process works well in the case of intermediaries
-because the client suggested priorities are passed to the origin, giving it the
-opportunity to improve the priority information before the intermediary
-allocates resources to the response.
+The "Priority" header field can be attached to responses, it is an explicit
+signal that allows a server to collaborate in the prioritization process by
+sending new priority parameter values or confirming the client suggestion. When
+an intermediary is present, the client-suggested priority is passed to the
+origin server, which gives it the opportunity to improve the priority
+information. The intermediary can use the origin server response to decide how
+to best prioritize serving the response.
 
 For example, a client using an HTML document discovers several inline images and
 requests them with a low urgency via an intermediary. The origin server has

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -296,7 +296,7 @@ signal that allows a server to collaborate in the prioritization process by
 sending new priority parameter values or confirming the client suggestion. When
 an intermediary is present, the client-suggested priority is passed to the
 origin server, which gives it the opportunity to improve the priority
-information. The intermediary can use the origin server response to decide how
+information. The intermediary can then use the origin server response to decide how
 to best prioritize serving the response.
 
 For example, a client using an HTML document discovers several inline images and

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -99,7 +99,7 @@ The Priority HTTP header field can appear in requests and responses. A client
 uses it to specify the priority of the response. A server uses it to inform
 the client that the priority was overwritten. An intermediary can use the
 Priority information from client requests and server responses to correct or
-amend the precedence to suit it (see {{collaboration}}).
+amend the precedence to suit it (see {{merging}}).
 
 The value of the Priority header field is a Structured Headers
 {{!I-D.ietf-httpbis-header-structure}} Dictionary.  Each dictionary member
@@ -329,7 +329,7 @@ information is acted on is described lightly in {{?RFC7540}} Section 5.3:
   therefore only a suggestion.
 
 The client is not alone in understanding the best way to prioritize a request. A
-server's prioritization decision is driven by a number of factors such as the
+server's prioritization decision can be driven by a number of factors such as the
 selected representation ({{?RFC7231}}, Section 3), data locality, resource
 contention, load balancing across multiple clients, application-specific
 annotations etc. When it generates responses it might determine that the
@@ -362,7 +362,7 @@ reprioritization that requires a non-request or non-response carriage mechanism
 
 Today's HTTP/2 priority information is exchanged as frames and restricted to
 clients. In order to support the new process, changes to frames and their
-handling are required. Extending behavior at that this level has proven hard
+handling are required. Extending behavior at that this level has proven hard to
 achieve in Internet deployments with challenges including availability of APIs,
 configuration specification and storage, coordination across endpoints, ease of
 migration, portability across HTTP versions, and extensibility of the extension


### PR DESCRIPTION
This goes someway to addressing #33.

I deviated from my original plan and focused more on what H2 refers to as a prioritization process. I highlight that H2 only gives clients explicit input to the process, and attempt to describe that a more collaborative process could improve the overall usability for the client. (_aside: collaboration replaces the use of override_).

I also try to explain and delineate between the initial priority that is possible with the Priority header, and subsequent reprioritization that might require a frame or whatever.

Finally, we go back to the merging example but call it collaboration.

Its not perfect, we might want to chop it up and only pull out the useful bits. Elsewhere some opinions have been shared on breaking up into separate documents so we might want to put some of this text elsewhere.