### PR TITLE
Negotiating priorities using a new SETTING

### DIFF
--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -143,8 +143,8 @@ lack thereof of priority frames.
 If the value is non-zero, then the least significant 8 bits indicates the
 peer's preferred priority scheme, the second least significant 8 bits
 indicates the peer's second choice, and so on.  This allows expressing
-support for 4 schemes in HTTP/2 and 7 in HTTP/3.  If the value is non-zero,
-all 8 bit scheme identifiers MUST NOT be 0.
+support for 4 schemes in HTTP/2 and 7 in HTTP/3.  If any octet is 0,
+all more significant octets MUST also be 0.
 
 In HTTP/2, the setting SHOULD appear in the first SETTINGS frame and peers
 MUST NOT process the setting if it's received multiple times in order to

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -105,22 +105,26 @@ Section 5.3, which some implementers have opted not to fully support.
 The lack of signalling about the status of the implementation has
 caused several implementations to implement heuristics to detect when
 the clients they are connected to do not support priorities as
-defined and take steps to compensate for that.  The intent of this
-negotiation is to provide an affirmative signalling mechanism for each
-peer to communicate which, if any, priority schemes are supported,
-including the priority scheme as defined in [RFC7540], Section 5.3.
+defined and take steps to compensate for that.
+
+The intent of this negotiation is to provide a signalling mechanism
+for each peer to communicate which, if any, priority schemes are
+supported, as well as a ranked preference.
 
 For both HTTP/2 and HTTP/3, either peer's SETTINGS may arrive first,
 so any negotiation must be unilateral and not rely upon receiving
 the peer's SETTINGS value.
 
 Implementations are likely to only use one prioritization scheme at
-once, so the SETTINGS SHOULD be sent prior to the first request.
-In HTTP/3, the SETTINGS may arrive after the first request even if
-they are sent first.  In order to avoid the server choosing
-incorrectly in HTTP/3, the client SHOULD only send priority
-information via its most preferred scheme until it knows what is
-supported by the server.
+once, and may be unable to change the scheme once established, so the
+setting MUST be sent prior to the first request if it is ever sent.
+In HTTP/3, SETTINGS may arrive after the first request even if
+they are sent first.  In order to avoid the server incorrectly
+choosing a priority scheme in HTTP/3, the client SHOULD only send
+priority information via its most preferred scheme until it knows
+what is supported by the server.  The client may also delay
+sending priority information until after it knows what the server
+supports.
 
 ## The SETTINGS_PRIORITIES SETTINGS Parameter
 
@@ -138,7 +142,8 @@ lack thereof of priority frames.
 If the value is non-zero, then the least significant 8 bits indicates the
 peer's preferred priority scheme, the second least significant 8 bits
 indicates the peer's second choice, and so on.  This allows expressing
-support for 4 schemes in HTTP/2 and 7 in HTTP/3.
+support for 4 schemes in HTTP/2 and 7 in HTTP/3.  If the value is non-zero,
+all 8 bit scheme identifiers MUST NOT be 0.
 
 In HTTP/2, the setting SHOULD appear in the first SETTINGS frame and peers
 MUST NOT process the setting if it's received multiple times in order to
@@ -148,9 +153,9 @@ If there is a prioritization scheme supported by both the client and server,
 then the client's preference order prevails and both peers SHOULD
 only use the agreed upon priority scheme for the remainder of the session.
 
-An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities as defined
-in Section 5.3 of [RFC7540] and is an error in HTTP/3 because there is not
-a clean mapping to HTTP/3.
+An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities
+as defined in Section 5.3 of [RFC7540] and is an error in HTTP/3 because
+there is not a clean mapping to HTTP/3.
 
 
 

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -153,7 +153,7 @@ avoid changing the agreed upon prioritization scheme.
 If there is a prioritization scheme supported by both the client and server,
 then the servers's preference order prevails and both peers SHOULD
 only use the agreed upon priority scheme for the remainder of the session.
-The server chooses becasue it is in the best position to know what
+The server chooses because it is in the best position to know what
 information from the client is of the most value.
 
 An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -109,7 +109,7 @@ defined and take steps to compensate for that.
 
 The intent of this negotiation is to provide a signalling mechanism
 for each peer to communicate which, if any, priority schemes are
-supported, as well as a ranked preference.
+supported, as well as the client's ranked preference.
 
 For both HTTP/2 and HTTP/3, either peer's SETTINGS may arrive first,
 so any negotiation must be unilateral and not rely upon receiving

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -98,6 +98,62 @@ The terms sh-token and sh-boolean are imported from
 Example HTTP requests and responses use the HTTP/2-style formatting from
 {{?RFC7540}}.
 
+# Negotiating Priorities
+
+The HTTP/2 specification defines a priority scheme in [RFC7540],
+Section 5.3, which some implementers have opted not to fully support.
+The lack of signalling about the status of the implementation has
+caused several implementations to implement heuristics to detect when
+the clients they are connected to do not support priorities as
+defined and take steps to compensate for that.  The intent of this
+negotiation is to provide an affirmative signalling mechanism for each
+peer to communicate which, if any, priority schemes are supported,
+including the priority scheme as defined in [RFC7540], Section 5.3.
+
+For both HTTP/2 and HTTP/3, either peer's SETTINGS may arrive first,
+so any negotiation must be unilateral and not rely upon receiving
+the peer's SETTINGS value.
+
+Implementations are likely to only use one prioritization scheme at
+once, so the SETTINGS SHOULD be sent prior to the first request.
+In HTTP/3, the SETTINGS may arrive after the first request even if
+they are sent first.  In order to avoid the server choosing
+incorrectly in HTTP/3, the client SHOULD only send priority
+information via its most preferred scheme until it knows what is
+supported by the server.
+
+## The SETTINGS_PRIORITIES SETTINGS Parameter
+
+This document adds a new SETTINGS parameter to those defined by
+[RFC7540], Section 6.5.2.
+
+The new parameter name is SETTINGS_PRIORITIES, which allows both
+peers to indicate which prioritization schemes they support.
+
+A value of 0 indicates no support for priorities. If either side sends the
+parameter with a value of 0, clients SHOULD NOT send priority frames
+and servers SHOULD NOT make any assumptions based on the presence or
+lack thereof of priority frames.
+
+If the value is non-zero, then the least significant 8 bits indicates the
+peer's preferred priority scheme, the second least significant 8 bits
+indicates the peer's second choice, and so on.  This allows expressing
+support for 4 schemes in HTTP/2 and 7 in HTTP/3.
+
+In HTTP/2, the setting SHOULD appear in the first SETTINGS frame and peers
+MUST NOT process the setting if it's received multiple times in order to
+avoid changing the agreed upon prioritization scheme.
+
+If there is a prioritization scheme supported by both the client and server,
+then the client's preference order prevails and both peers SHOULD
+only use the agreed upon priority scheme for the remainder of the session.
+
+An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities as defined
+in Section 5.3 of [RFC7540] and is an error in HTTP/3 because there is not
+a clean mapping to HTTP/3.
+
+
+
 # The Priority HTTP Header Field
 
 The Priority HTTP header field can appear in requests and responses. A client

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -109,7 +109,7 @@ defined and take steps to compensate for that.
 
 The intent of this negotiation is to provide a signalling mechanism
 for each peer to communicate which, if any, priority schemes are
-supported, as well as the client's ranked preference.
+supported, as well as the server's ranked preference.
 
 For both HTTP/2 and HTTP/3, either peer's SETTINGS may arrive first,
 so any negotiation must be unilateral and not rely upon receiving
@@ -121,10 +121,11 @@ setting MUST be sent prior to the first request if it is ever sent.
 In HTTP/3, SETTINGS may arrive after the first request even if
 they are sent first.  In order to avoid the server incorrectly
 choosing a priority scheme in HTTP/3, the client SHOULD only send
-priority information via its most preferred scheme until it knows
-what is supported by the server.  The client may also delay
-sending priority information until after it knows what the server
-supports.
+priority information prior to receiving the server's SETTINGS if
+it only offers a single scheme.  If it offers multiple schemes,
+the client SHOULD delay sending priority information until
+after it knows what the server supports, or risk the server
+choosing a sub-optimal scheme.
 
 ## The SETTINGS_PRIORITIES SETTINGS Parameter
 
@@ -150,8 +151,10 @@ MUST NOT process the setting if it's received multiple times in order to
 avoid changing the agreed upon prioritization scheme.
 
 If there is a prioritization scheme supported by both the client and server,
-then the client's preference order prevails and both peers SHOULD
+then the servers's preference order prevails and both peers SHOULD
 only use the agreed upon priority scheme for the remainder of the session.
+The server chooses becasue it is in the best position to know what
+information from the client is of the most value.
 
 An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities
 as defined in Section 5.3 of [RFC7540] and is an error in HTTP/3 because


### PR DESCRIPTION
Summarizes what I understood from the last design team meeting.  Uses 8 bit codepoints to specify priority schemes in a new HTTP/2 and HTTP/3 SETTING.

I did make a design change so the server's preference to win over the client's, based on the belief that the server is the consumer of the information the client is sending, so knows what information is most valuable.