### PR TITLE
Consolidation of the priority problem statement

### DIFF
--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -113,7 +113,7 @@ defined and take steps to compensate for that.
 
 The intent of this negotiation is to provide a signalling mechanism
 for each peer to communicate which, if any, priority schemes are
-supported, as well as the client's ranked preference.
+supported, as well as the server's ranked preference.
 
 For both HTTP/2 and HTTP/3, either peer's SETTINGS may arrive first,
 so any negotiation must be unilateral and not rely upon receiving
@@ -125,10 +125,11 @@ setting MUST be sent prior to the first request if it is ever sent.
 In HTTP/3, SETTINGS may arrive after the first request even if
 they are sent first.  In order to avoid the server incorrectly
 choosing a priority scheme in HTTP/3, the client SHOULD only send
-priority information via its most preferred scheme until it knows
-what is supported by the server.  The client may also delay
-sending priority information until after it knows what the server
-supports.
+priority information prior to receiving the server's SETTINGS if
+it only offers a single scheme.  If it offers multiple schemes,
+the client SHOULD delay sending priority information until
+after it knows what the server supports, or risk the server
+choosing a sub-optimal scheme.
 
 ## The SETTINGS_PRIORITIES SETTINGS Parameter
 
@@ -154,8 +155,10 @@ MUST NOT process the setting if it's received multiple times in order to
 avoid changing the agreed upon prioritization scheme.
 
 If there is a prioritization scheme supported by both the client and server,
-then the client's preference order prevails and both peers SHOULD
+then the servers's preference order prevails and both peers SHOULD
 only use the agreed upon priority scheme for the remainder of the session.
+The server chooses becasue it is in the best position to know what
+information from the client is of the most value.
 
 An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities
 as defined in Section 5.3 of [RFC7540] and is an error in HTTP/3 because

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -98,7 +98,65 @@ The terms sh-token and sh-boolean are imported from
 Example HTTP requests and responses use the HTTP/2-style formatting from
 {{?RFC7540}}.
 
-This document uses the variable-length integer encoding from {{!I-D.ietf-quic-transport}}.
+This document uses the variable-length integer encoding from
+{{!I-D.ietf-quic-transport}}.
+
+
+# Negotiating Priorities
+
+The HTTP/2 specification defines a priority scheme in [RFC7540],
+Section 5.3, which some implementers have opted not to fully support.
+The lack of signalling about the status of the implementation has
+caused several implementations to implement heuristics to detect when
+the clients they are connected to do not support priorities as
+defined and take steps to compensate for that.  The intent of this
+negotiation is to provide an affirmative signalling mechanism for each
+peer to communicate which, if any, priority schemes are supported,
+including the priority scheme as defined in [RFC7540], Section 5.3.
+
+For both HTTP/2 and HTTP/3, either peer's SETTINGS may arrive first,
+so any negotiation must be unilateral and not rely upon receiving
+the peer's SETTINGS value.
+
+Implementations are likely to only use one prioritization scheme at
+once, so the SETTINGS SHOULD be sent prior to the first request.
+In HTTP/3, the SETTINGS may arrive after the first request even if
+they are sent first.  In order to avoid the server choosing
+incorrectly in HTTP/3, the client SHOULD only send priority
+information via its most preferred scheme until it knows what is
+supported by the server.
+
+## The SETTINGS_PRIORITIES SETTINGS Parameter
+
+This document adds a new SETTINGS parameter to those defined by
+[RFC7540], Section 6.5.2.
+
+The new parameter name is SETTINGS_PRIORITIES, which allows both
+peers to indicate which prioritization schemes they support.
+
+A value of 0 indicates no support for priorities. If either side sends the
+parameter with a value of 0, clients SHOULD NOT send priority frames
+and servers SHOULD NOT make any assumptions based on the presence or
+lack thereof of priority frames.
+
+If the value is non-zero, then the least significant 8 bits indicates the
+peer's preferred priority scheme, the second least significant 8 bits
+indicates the peer's second choice, and so on.  This allows expressing
+support for 4 schemes in HTTP/2 and 7 in HTTP/3.
+
+In HTTP/2, the setting SHOULD appear in the first SETTINGS frame and peers
+MUST NOT process the setting if it's received multiple times in order to
+avoid changing the agreed upon prioritization scheme.
+
+If there is a prioritization scheme supported by both the client and server,
+then the client's preference order prevails and both peers SHOULD
+only use the agreed upon priority scheme for the remainder of the session.
+
+An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities as defined
+in Section 5.3 of [RFC7540] and is an error in HTTP/3 because there is not
+a clean mapping to HTTP/3.
+
+
 
 # The Priority HTTP Header Field
 

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -96,26 +96,27 @@ HTTP/2 introduced a complex prioritization signaling scheme that used a
 combination of dependencies and weights, formed into an unbalanced tree. This
 scheme suffers from poor deployment and interoperability.
 
-The rich flexibility permitted in tree building is rarely excersised by clients;
-they generally either chosen a model optimized for a web use case or do nothing
-at all.
+The rich flexibility of client-driven HTTP/2 prioritization tree building is
+rarely excercised; experience shows that clients either choose a single model
+optimized for a web use case (and don't vary it) or do nothing at all. But every
+client builds their in a different way, which makes it difficult for servers to
+understand their intent and act accordingly.
 
-Many server implementations do not include support for this scheme, some
-favoring instead bespoke server-driven schemes based on heuristics and other
-hints, like the content type of resources and the order in which requests
-arrive. For example, a server, with knowledge of the document structure, might
-want to prioritize the delivery of images that are critical to user experience
-above other images, but below the CSS files. But with the HTTP/2 prioritization
-scheme, it is impossible for the server to determine how such images should be
-prioritized against other responses that use the client-driven prioritization
-tree, because every client builds the HTTP/2 prioritization tree in a different
-way.
+Many server implementations do not include support for the HTTP/2 priority
+scheme, some favoring instead bespoke server-driven schemes based on heuristics
+and other hints, like the content type of resources and the order in which
+requests arrive. For example, a server, with knowledge of the document
+structure, might want to prioritize the delivery of images that are critical to
+user experience above other images, but below the CSS files. Since client trees
+vary, it is impossible for the server to determine how such images should be
+prioritized against other responses.
 
-Intermediaries can coalesce multiple HTTP/2 clients into a single upstream
-HTTP/2 connection and the prioritization scheme allows for this. However most
-intermediaries do not support this and it does not define a method that can be
-used by a server to express the priority of a response. Without such a method,
-intermediaries cannot coordinate client-driven and server-driven priorities.
+The HTTP/2 scheme allows intermediaries to coalesce multiple client trees into a
+single tree that is used for a single upstream HTTP/2 connection. However, most
+intermediaries do not support this. The scheme does not define a method that can
+be used by a server to express the priority of a response. Without such a
+method, intermediaries cannot coordinate client-driven and server-driven
+priorities.
 
 HTTP/2 describes denial-of-service considerations for implementations. On
 2019-08-13 Netflix issued an advisory notice about the discovery of several

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -157,7 +157,7 @@ avoid changing the agreed upon prioritization scheme.
 If there is a prioritization scheme supported by both the client and server,
 then the servers's preference order prevails and both peers SHOULD
 only use the agreed upon priority scheme for the remainder of the session.
-The server chooses becasue it is in the best position to know what
+The server chooses because it is in the best position to know what
 information from the client is of the most value.
 
 An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -109,22 +109,26 @@ Section 5.3, which some implementers have opted not to fully support.
 The lack of signalling about the status of the implementation has
 caused several implementations to implement heuristics to detect when
 the clients they are connected to do not support priorities as
-defined and take steps to compensate for that.  The intent of this
-negotiation is to provide an affirmative signalling mechanism for each
-peer to communicate which, if any, priority schemes are supported,
-including the priority scheme as defined in [RFC7540], Section 5.3.
+defined and take steps to compensate for that.
+
+The intent of this negotiation is to provide a signalling mechanism
+for each peer to communicate which, if any, priority schemes are
+supported, as well as a ranked preference.
 
 For both HTTP/2 and HTTP/3, either peer's SETTINGS may arrive first,
 so any negotiation must be unilateral and not rely upon receiving
 the peer's SETTINGS value.
 
 Implementations are likely to only use one prioritization scheme at
-once, so the SETTINGS SHOULD be sent prior to the first request.
-In HTTP/3, the SETTINGS may arrive after the first request even if
-they are sent first.  In order to avoid the server choosing
-incorrectly in HTTP/3, the client SHOULD only send priority
-information via its most preferred scheme until it knows what is
-supported by the server.
+once, and may be unable to change the scheme once established, so the
+setting MUST be sent prior to the first request if it is ever sent.
+In HTTP/3, SETTINGS may arrive after the first request even if
+they are sent first.  In order to avoid the server incorrectly
+choosing a priority scheme in HTTP/3, the client SHOULD only send
+priority information via its most preferred scheme until it knows
+what is supported by the server.  The client may also delay
+sending priority information until after it knows what the server
+supports.
 
 ## The SETTINGS_PRIORITIES SETTINGS Parameter
 
@@ -142,7 +146,8 @@ lack thereof of priority frames.
 If the value is non-zero, then the least significant 8 bits indicates the
 peer's preferred priority scheme, the second least significant 8 bits
 indicates the peer's second choice, and so on.  This allows expressing
-support for 4 schemes in HTTP/2 and 7 in HTTP/3.
+support for 4 schemes in HTTP/2 and 7 in HTTP/3.  If the value is non-zero,
+all 8 bit scheme identifiers MUST NOT be 0.
 
 In HTTP/2, the setting SHOULD appear in the first SETTINGS frame and peers
 MUST NOT process the setting if it's received multiple times in order to
@@ -152,9 +157,9 @@ If there is a prioritization scheme supported by both the client and server,
 then the client's preference order prevails and both peers SHOULD
 only use the agreed upon priority scheme for the remainder of the session.
 
-An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities as defined
-in Section 5.3 of [RFC7540] and is an error in HTTP/3 because there is not
-a clean mapping to HTTP/3.
+An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities
+as defined in Section 5.3 of [RFC7540] and is an error in HTTP/3 because
+there is not a clean mapping to HTTP/3.
 
 
 

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -147,8 +147,8 @@ lack thereof of priority frames.
 If the value is non-zero, then the least significant 8 bits indicates the
 peer's preferred priority scheme, the second least significant 8 bits
 indicates the peer's second choice, and so on.  This allows expressing
-support for 4 schemes in HTTP/2 and 7 in HTTP/3.  If the value is non-zero,
-all 8 bit scheme identifiers MUST NOT be 0.
+support for 4 schemes in HTTP/2 and 7 in HTTP/3.  If any octet is 0,
+all more significant octets MUST also be 0.
 
 In HTTP/2, the setting SHOULD appear in the first SETTINGS frame and peers
 MUST NOT process the setting if it's received multiple times in order to

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -113,7 +113,7 @@ defined and take steps to compensate for that.
 
 The intent of this negotiation is to provide a signalling mechanism
 for each peer to communicate which, if any, priority schemes are
-supported, as well as a ranked preference.
+supported, as well as the client's ranked preference.
 
 For both HTTP/2 and HTTP/3, either peer's SETTINGS may arrive first,
 so any negotiation must be unilateral and not rely upon receiving

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -59,32 +59,14 @@ those HTTP responses, that it sends.
 HTTP/2 ({{?RFC7540}}) provides such a prioritization scheme. A client sends a
 series of PRIORITY frames to communicate to the server a “priority tree”; this
 represents the client's preferred ordering and weighted distribution of the
-bandwidth among the HTTP responses.  However, the design has shortcomings:
+bandwidth among the HTTP responses. However, the design and implementation of
+this scheme has been observed to have shortcomings, explained in {{motivation}}.
 
-* Its complexity has led to varying levels of support by HTTP/2 clients and
-  servers.
-* It is hard to coordinate with server-driven prioritization.  For example, a
-  server, with knowledge of the document structure, might want to prioritize
-  the delivery of images that are critical to user experience above other
-  images, but below the CSS files.  But with the HTTP/2 prioritization scheme,
-  it is impossible for the server to determine how such images should be
-  prioritized against other responses that use the client-driven prioritization
-  tree, because every client builds the HTTP/2 prioritization tree in a
-  different way.
-* It does not define a method that can be used by a server to express the
-  priority of a response.  Without such a method, intermediaries cannot
-  coordinate client-driven and server-driven priorities.
-* The design cannot be ported cleanly to HTTP/3 ({{!I-D.ietf-quic-http}}).  One
-  of the primary goals of HTTP/3 is to minimize head-of-line blocking.
-  Transmitting the evolving representation of a "prioritization tree" from the
-  client to the server requires head-of-line blocking.
-
-Based on these observations, this document defines the Priority HTTP header
-field that can be used by both the client and the server to specify the
-precedence of HTTP responses in a standardized, extensible, protocol-version-
-independent, end-to-end format. This header-based prioritization scheme can act
-as a substitute for the HTTP/2 frame-based prioritization scheme (see
-{{coexistence}}).
+This document defines the Priority HTTP header field that can be used by both
+client and server to specify the precedence of HTTP responses in a
+standardized, extensible, protocol-version- independent, end-to-end format. This
+header-based prioritization scheme can act as a substitute for the HTTP/2
+frame-based prioritization scheme (see {{coexistence}}).
 
 ## Notational Conventions
 
@@ -102,18 +84,65 @@ This document uses the variable-length integer encoding from
 {{!I-D.ietf-quic-transport}}.
 
 
+# Motivation for Replacing HTTP/2 Priorities {#motivation}
+
+An important feature of any implementation of a protocol that provides
+multiplexing is the ability to prioritize the sending of information. This was
+an important realization in the design of HTTP/2. Prioritization is a
+difficult problem, so it will always be suboptimal, particularly if one endpoint
+operates in ignorance of the needs of its peer.
+
+HTTP/2 introduced a complex prioritization signaling scheme that used a
+combination of dependencies and weights, formed into an unbalanced tree. This
+scheme suffers from poor deployment and interoperability.
+
+The rich flexibility permitted in tree building is rarely excersised by clients;
+they generally either chosen a model optimized for a web use case or do nothing
+at all.
+
+Many server implementations do not include support for this scheme, some
+favoring instead bespoke server-driven schemes based on heuristics and other
+hints, like the content type of resources and the order in which requests
+arrive. For example, a server, with knowledge of the document structure, might
+want to prioritize the delivery of images that are critical to user experience
+above other images, but below the CSS files. But with the HTTP/2 prioritization
+scheme, it is impossible for the server to determine how such images should be
+prioritized against other responses that use the client-driven prioritization
+tree, because every client builds the HTTP/2 prioritization tree in a different
+way.
+
+Intermediaries can coalesce multiple HTTP/2 clients into a single upstream
+HTTP/2 connection and the prioritization scheme allows for this. However most
+intermediaries do not support this and it does not define a method that can be
+used by a server to express the priority of a response. Without such a method,
+intermediaries cannot coordinate client-driven and server-driven priorities.
+
+HTTP/2 describes denial-of-service considerations for implementations. On
+2019-08-13 Netflix issued an advisory notice about the discovery of several
+resource exhaustion vectors affecting multiple HTTP/2 implementations. One
+attack, CVE-2019-9513 aka "Resource Loop", is based on manipulation of the
+priority tree.
+
+The HTTP/2 scheme depends on in-order delivery, so it is unsuitable for use in
+protocols like HTTP/3 {{?I-D.ietf-quic-http}}, which attempts to avoid global
+ordering.
+
+Considering the problems with deployment and adaptability to HTTP/3, retaining
+the HTTP/2 priority scheme increases the complexity of the entire system without
+any evidence that the value it provides offsets that complexity.
+
+The problems laid out above are motivation for the alternative prioriization
+scheme presented in this document. In order to support deployement of new
+schemes, a general-purpose negotiation mechanism is specified in
+{{negotiating-priorities}}.
+
+
+
 # Negotiating Priorities
 
-The HTTP/2 specification defines a priority scheme in [RFC7540],
-Section 5.3, which some implementers have opted not to fully support.
-The lack of signalling about the status of the implementation has
-caused several implementations to implement heuristics to detect when
-the clients they are connected to do not support priorities as
-defined and take steps to compensate for that.
-
-The intent of this negotiation is to provide a signalling mechanism
-for each peer to communicate which, if any, priority schemes are
-supported, as well as the server's ranked preference.
+The document specifies a negotiation mechanism that allows each peer to
+communicate which, if any, priority schemes are supported, as well as the
+server's ranked preference.
 
 For both HTTP/2 and HTTP/3, either peer's SETTINGS may arrive first,
 so any negotiation must be unilateral and not rely upon receiving
@@ -583,6 +612,11 @@ priorities in <http://tools.ietf.org/agenda/83/slides/slides-83-httpbis-5.pdf>.
 In <https://github.com/pmeenan/http3-prioritization-proposal>, Patrick Meenan
 advocates for representing the priorities using a tuple of urgency and
 concurrency.
+
+The motivation for defining an alternative to HTTP/2 priorities is drawn from
+discussion within the broad HTTP community. Special thanks to Roberto Peon,
+Martin Thomson and Netflix for text that was incorporated explicitly in this
+document.
 
 Many thanks to Robin Marx, Patrick Meenan and Ian Swett for their feedback.
 

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -97,12 +97,12 @@ combination of dependencies and weights, formed into an unbalanced tree. This
 scheme suffers from poor deployment and interoperability.
 
 The rich flexibility of client-driven HTTP/2 prioritization tree building is
-rarely excercised; experience shows that clients either choose a single model
+rarely exercised; experience shows that clients either choose a single model
 optimized for a web use case (and don't vary it) or do nothing at all. But every
-client builds their in a different way, which makes it difficult for servers to
-understand their intent and act accordingly.
+client builds their prioritization tree in a different way, which makes it
+difficult for servers to understand their intent and act accordingly.
 
-Many server implementations do not include support for the HTTP/2 priority
+Many HTTP/2 server implementations do not include support for the priority
 scheme, some favoring instead bespoke server-driven schemes based on heuristics
 and other hints, like the content type of resources and the order in which
 requests arrive. For example, a server, with knowledge of the document
@@ -132,8 +132,8 @@ Considering the problems with deployment and adaptability to HTTP/3, retaining
 the HTTP/2 priority scheme increases the complexity of the entire system without
 any evidence that the value it provides offsets that complexity.
 
-The problems laid out above are motivation for the alternative prioriization
-scheme presented in this document. In order to support deployement of new
+The problems laid out above are motivation for the alternative prioritization
+scheme presented in this document. In order to support deployment of new
 schemes, a general-purpose negotiation mechanism is specified in
 {{negotiating-priorities}}.
 


### PR DESCRIPTION
On the priority team mailing list I advocated for a [consolidation of the problem statement](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/http-priorities-design-team/an06MqgKgIE)

This PR builds on top of #58, creating a new section that combines that text, with text from the introduction and pulls in some of Roberto's text. All of that happens on https://github.com/kazuho/draft-kazuho-httpbis-priority/commit/b2b927ccbeea76f9edcb5e49ad9be06530d9e2ab

@rmarx I didn't pull anything specifically from your paper but if you feel there is something that I don't cover then please do suggest it