### PR TITLE
Split prioritization into scheme and header sections

### DIFF
--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -195,10 +195,10 @@ only use the agreed upon priority scheme for the remainder of the session.
 The server chooses because it is in the best position to know what
 information from the client is of the most value.
 
-Once the negotiation is complete, endpoints MAY stop sending hop-by-hop	
-prioritization signals that were not negotiated in order to conserve bandwidth.	
-However, endpoints SHOULD continue sending end-to-end signals (e.g., the	
-Priority header field), as that might have meaningful effect to other nodes that	
+Once the negotiation is complete, endpoints MAY stop sending hop-by-hop
+prioritization signals that were not negotiated in order to conserve bandwidth.
+However, endpoints SHOULD continue sending end-to-end signals (e.g., the
+Priority header field), as that might have meaningful effect to other nodes that
 handle the HTTP message.
 
 An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities
@@ -217,7 +217,7 @@ has negotiated the use of the extensible priority scheme (see {{fairness}}).
 
 # Urgency Prioritization
 
-Urgency based prioritization uses two fields, `urgency` and `progressive` to
+Urgency prioritization uses two parameters, `urgency` and `progressive` to
 indicate the relative urgency of requests and whether responses should be
 interleaved with other responses at the same priority.
 
@@ -340,8 +340,6 @@ uses it to specify the priority of the response. A server uses it to inform
 the client that the priority was overwritten. An intermediary can use the
 Priority information from client requests and server responses to correct or
 amend the precedence to suit it (see {{merging}}).
-
-Unknown parameters MUST be ignored.
 
 
 ## urgency

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -195,6 +195,12 @@ only use the agreed upon priority scheme for the remainder of the session.
 The server chooses because it is in the best position to know what
 information from the client is of the most value.
 
+Once the negotiation is complete, endpoints MAY stop sending hop-by-hop	
+prioritization signals that were not negotiated in order to conserve bandwidth.	
+However, endpoints SHOULD continue sending end-to-end signals (e.g., the	
+Priority header field), as that might have meaningful effect to other nodes that	
+handle the HTTP message.
+
 An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities
 as defined in Section 5.3 of [RFC7540] and is an error in HTTP/3 because
 there is not a clean mapping to HTTP/3.
@@ -203,11 +209,6 @@ there is not a clean mapping to HTTP/3.
 
 The extensible priority scheme is negotiated using the described mechanism. It is
 identified by the 8-bit value of 2.
-
-Endpoints using this scheme SHOULD emit the Priority header field regardless of
-the result of the negotiation, as that negotiation is a hop-by-hop agreement,
-whereas the Priority header field is an end-to-end signal that might have
-meaningful effect to other nodes that handle the HTTP message.
 
 An intermediary connecting to a backend server SHOULD declare support for the
 extensible priority scheme when and only when all the requests that are to be


### PR DESCRIPTION
I added a bit of text to introduce the 'Urgency' prioritization scheme, but besides that this is just moving text around.  I think the header section now needs more explanation, but that can be added in a different PR.

I'm happy to pick a different name from 'Urgency' as well, but it seemed like the most obvious choice.