### PR TITLE
Add formal scheme identifier names and IANA table

### DIFF
--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -162,21 +162,21 @@ stream-level priority signal prior to receiving the SETTINGS frame.
 
 ## The SETTINGS_PRIORITIES SETTINGS Parameter
 
-This document adds a new SETTINGS parameter to those defined by
-[RFC7540], Section 6.5.2.
+This document defines a new SETTINGS_PRIORITIES parameter (0x9) for HTTP/2 and
+HTTP/3, which allows both peers to indicate which prioritization schemes they
+support. The value of this parameter is interpreted in two ways depending on if it is
+zero or non-zero.
 
-The new parameter name is SETTINGS_PRIORITIES, which allows both
-peers to indicate which prioritization schemes they support.
+If the setting has a value of zero it indicates no support for priorities. If
+either side sends the parameter with a value of zero, clients SHOULD NOT send
+hop-by-hop priority signals (e.g., HTTP/2 PRIORITY frame) and servers SHOULD NOT
+make any assumptions based on the presence or lack thereof of such signals.
 
-A value of 0 indicates no support for priorities. If either side sends the
-parameter with a value of 0, clients SHOULD NOT send hop-by-hop prioritiy
-signals (e.g., HTTP/2 PRIORITY frame) and servers SHOULD NOT make any
-assumptions based on the presence or lack thereof of such signals.
-
-If the value is non-zero, then the least significant 8 bits indicate the
-sender's most preferred priority scheme, the second least significant 8 bits
-indicate the sender's second choice, and so on. This allows expressing
-support for 4 schemes in HTTP/2 and 7 in HTTP/3.
+If the value is non-zero, then it is interpreted as an ordered preference list
+of prioritization schemes represented by 8-bit values. The least significant 8
+bits indicate the sender's most preferred priority scheme, the second least
+significant 8 bits indicate the sender's second choice, and so on. This allows
+expressing support for 4 schemes in HTTP/2 and 7 in HTTP/3.
 
 A sender MUST comply with the following restrictions when constructing a
 preference list: duplicate 8-bit values (excluding the value 0) MUST NOT be used,
@@ -190,7 +190,7 @@ MUST NOT process the setting if it's received multiple times in order to
 avoid changing the agreed upon prioritization scheme.
 
 If there is a prioritization scheme supported by both the client and server,
-then the servers's preference order prevails and both peers SHOULD
+then the server's preference order prevails and both peers SHOULD
 only use the agreed upon priority scheme for the remainder of the session.
 The server chooses because it is in the best position to know what
 information from the client is of the most value.
@@ -201,14 +201,25 @@ However, endpoints SHOULD continue sending end-to-end signals (e.g., the
 Priority header field), as that might have meaningful effect to other nodes that
 handle the HTTP message.
 
-An 8 bit value of 1 in HTTP/2 indicates support for HTTP/2 priorities
-as defined in Section 5.3 of [RFC7540] and is an error in HTTP/3 because
-there is not a clean mapping to HTTP/3.
+## Defined Prioritization Scheme Values
 
-## Negotiating the Extensible Priority Scheme {#settings-this-scheme}
+This document defines two prioritization scheme values for use with the
+SETTINGS_PRIORITIES setting.
 
-The extensible priority scheme is negotiated using the described mechanism. It is
-identified by the 8-bit value of 2.
+### H2_TREE {#settings-h2-scheme}
+
+This document defines the priority scheme identifier H2_TREE (8-bit value of 1)
+that indicates support for HTTP/2-style priorities ({{!RFC7540}}, Section 5.3).
+
+The H2_TREE priority scheme identifier MUST NOT be be sent in an HTTP/3 settings
+because there is no defined mapping of this scheme. Endpoints MUST treat receipt
+of H2_TREE as a connection error of type H3_SETTINGS_ERROR.
+
+### EXT_PRI {#settings-this-scheme}
+
+This document defines the priority scheme identifier EXT_PRI (8-bit value of 2)
+that indicates support for the extensible priority scheme defined by the in the
+present document.
 
 An intermediary connecting to a backend server SHOULD declare support for the
 extensible priority scheme when and only when all the requests that are to be
@@ -617,10 +628,25 @@ This specification registers the following entry in the HTTP/2 Settings registry
 established by {{!RFC7540}}:
 
 Name:
-: SETTINGS_HEADER_BASED_PRIORITY:
+: SETTINGS_PRIORITIES
 
 Code:
-: 0xTBD
+: 0x9
+
+Initial value:
+: 0
+
+Specification:
+: This document
+
+This specification registers the following entry in the HTTP/2 Settings registry
+established by {{!I-D.ietf-quic-http}}:
+
+Name:
+: SETTINGS_PRIORITIES
+
+Code:
+: 0x9
 
 Initial value:
 : 0
@@ -651,6 +677,36 @@ Code:
 
 Specification:
 : This document
+
+## HTTP Prioritization Scheme Registry
+
+This document establishes a registry for HTTP prioritization scheme codes to be
+used in conjunction with the SETTINGS_PRIORITIES parameter. The "HTTP
+Prioritization Scheme" registry manages an 8-bit space. The "HTTP Prioritization
+Scheme" registry operates under either of the "IETF Review" or "IESG Approval"
+policies {{!RFC5226}} for values between 0x00 and 0xef, with values between 0xf0
+and 0xff being reserved for Experimental Use.
+
+New entries in this registry require the following information:
+
+Prioritization Scheme:
+: A name or label for the prioritization scheme.
+
+Code:
+: The 8-bit code assigned to the prioritization scheme.
+
+Specification:
+: A reference to a specification that includes a description of the
+prioritization scheme.
+
+The entries in the following table are registered by this document.
+
+| ----------------------| ------ | -------------------------- |
+| Prioritization Scheme |  Code  | Specification              |
+| --------------------- | :----: | -------------------------- |
+| H2_TREE               |   1    | {{settings-h2-scheme}}     |
+| EXT_PRI               |   2    | {{settings-this-scheme}}   |
+| --------------------- | ------ | -------------------------- |
 
 --- back
 

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -218,8 +218,8 @@ of H2_TREE as a connection error of type H3_SETTINGS_ERROR.
 ### EXT_PRI {#settings-this-scheme}
 
 This document defines the priority scheme identifier EXT_PRI (8-bit value of 2)
-that indicates support for the extensible priority scheme defined by the in the
-present document.
+that indicates support for the extensible priority scheme defined in the present
+document.
 
 An intermediary connecting to a backend server SHOULD declare support for the
 extensible priority scheme when and only when all the requests that are to be

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -215,9 +215,9 @@ The H2_TREE priority scheme identifier MUST NOT be be sent in an HTTP/3 settings
 because there is no defined mapping of this scheme. Endpoints MUST treat receipt
 of H2_TREE as a connection error of type H3_SETTINGS_ERROR.
 
-### EXT_PRI {#settings-this-scheme}
+### URGENCY {#settings-this-scheme}
 
-This document defines the priority scheme identifier EXT_PRI (8-bit value of 2)
+This document defines the priority scheme identifier URGENCY (8-bit value of 2)
 that indicates support for the extensible priority scheme defined in the present
 document.
 
@@ -705,7 +705,7 @@ The entries in the following table are registered by this document.
 | Prioritization Scheme |  Code  | Specification              |
 | --------------------- | :----: | -------------------------- |
 | H2_TREE               |   1    | {{settings-h2-scheme}}     |
-| EXT_PRI               |   2    | {{settings-this-scheme}}   |
+| URGENCY               |   2    | {{settings-this-scheme}}   |
 | --------------------- | ------ | -------------------------- |
 
 --- back


### PR DESCRIPTION
Fixes #56 by being more explicit about the 8-bit values that are used inside the new SETTINGS_PRIORITIES parameters.

It goes "whole hog" and claims a SETTINGS value rather than leaving it TBD (but i'm happy to roll that back if people feel strongly against it)

