### PR TITLE
Clarify when PRIORITY_UPDATE can be sent

### DIFF
--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -474,7 +474,7 @@ Empty:
 : A seven-bit field that has no semantic value.
 
 The HTTP/3 PRIORITY_UPDATE frame MUST NOT be sent with an invalid identifier including before the request stream
-has been opened or a PUSH_PROMISE for the corresponding PUSH_ID has been
+has been opened or a before a promised request has been
 received.
 
 In HTTP/3, the PRIORITY_UPDATE frame can arrive before any data is received

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -485,6 +485,17 @@ be opened, the frame SHOULD be buffered until the stream is opened and
 applied immediately after the HEADERS are parsed.  This consumes extra state
 on the peer, but existing stream limits bound the size of that state.
 
+The HTTP/3 PRIORITY_UPDATE frame is sent on the control stream. Because there
+are no ordering guarantees between streams, a client that reprioritizes a
+request before receiving the response data might cause the server to receive
+a PRIORITY_UPDATE for an unknown request. If the request stream ID is within
+bidirectional stream limits, the PRIORITY_UPDATE frame SHOULD be buffered
+until the stream is opened and applied immediately after the request message
+has been processed. Holding PRIORITY_UPDATES consumes extra state on the peer,
+although the size of the state is bounded by bidirectional stream limits. There
+is no bound on the number of PRIORITY_UPDATES that can be sent, so an
+endpoint SHOULD store only the most recently received frame.
+
 TODO: add more description of how to handle things like receiving
 PRIORITY_UPDATE on wrong stream, a PRIORITY_UPDATE with an invalid ID, etc.
 

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -408,7 +408,7 @@ HTTP/2 this is the Stream ID, in HTTP/3 this is either the Stream ID or Push ID.
 In HTTP/2 and HTTP/3, after a request message is sent on a stream, the stream
 transitions it into a state that prevents the client from sending additional
 frames on the stream. Modifying this behavior would require a semantic change
-to the protocol. this is avoided by restricting the stream on which a
+to the protocol, but this is avoided by restricting the stream on which a
 PRIORITY_UPDATE frame can be sent. In HTTP/2 the frame is on stream zero and
 in HTTP/3 it is sent on the
 control stream ({{!I-D.ietf-quic-http}}, Section 6.2.1).

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -476,7 +476,9 @@ Empty:
 
 The HTTP/3 PRIORITY_UPDATE frame MUST NOT be sent with an invalid identifier,
 including before the request stream has been opened or before a promised
-request has been received.
+request has been received.  If a server receives a PRIORITY_UPDATE specifying
+a push ID that has not been promised, it SHOULD be treated as a connection
+error of type H3_ID_ERROR.
 
 Because the HTTP/3 PRIORITY_UPDATE frame is sent on the control stream and
 there are no ordering guarantees between streams, a client that reprioritizes

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -436,7 +436,8 @@ frame header MUST be zero (0x0).
 {: #fig-h2-reprioritization-frame title="HTTP/2 PRIORITY_UPDATE Frame Payload"}
 
 The HTTP/2 PRIORITY_UPDATE frame MUST NOT be sent prior to opening the
-stream.
+stream.  If a PRIORITY_UPDATE is received prior to the stream being opened,
+it MAY close the connection error.
 
 TODO: add more description of how to handle things like receiving
 PRIORITY_UPDATE on wrong stream, a PRIORITY_UPDATE with an invalid ID, etc.
@@ -473,9 +474,9 @@ Element ID is interpreted as a Push ID.
 Empty:
 : A seven-bit field that has no semantic value.
 
-The HTTP/3 PRIORITY_UPDATE frame MUST NOT be sent with an invalid identifier including before the request stream
-has been opened or a before a promised request has been
-received.
+The HTTP/3 PRIORITY_UPDATE frame MUST NOT be sent with an invalid identifier,
+including before the request stream has been opened or before a promised
+request has been received.
 
 In HTTP/3, the PRIORITY_UPDATE frame can arrive before any data is received
 on the corresponding stream or server push due to reordering or proactively

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -405,12 +405,13 @@ reprioritization. It carries updated priority parameters and references the
 target of the reprioritization based on a version-specific identifier; in
 HTTP/2 this is the Stream ID, in HTTP/3 this is either the Stream ID or Push ID.
 
-In HTTP/2 and HTTP/3 a request message sent on a stream transitions it into a
-state that prevents the client from sending additional frames on the stream.
-Modifying this behavior requires a semantic change to the protocol, this is
-avoided by restricting the stream on which a PRIORITY_UPDATE frame can be sent.
-In HTTP/2 the frame is on stream zero and in HTTP/3 it is sent on the control
-stream ({{!I-D.ietf-quic-http}}, Section 6.2.1).
+In HTTP/2 and HTTP/3, after a request message is sent on a stream, the stream
+transitions it into a state that prevents the client from sending additional
+frames on the stream. Modifying this behavior would require a semantic change
+to the protocol. this is avoided by restricting the stream on which a
+PRIORITY_UPDATE frame can be sent. In HTTP/2 the frame is on stream zero and
+in HTTP/3 it is sent on the
+control stream ({{!I-D.ietf-quic-http}}, Section 6.2.1).
 
 Unlike the header field, the reprioritization frame is a hop-by-hop signal.
 
@@ -433,6 +434,9 @@ frame header MUST be zero (0x0).
  +---------------------------------------------------------------+
 ~~~
 {: #fig-h2-reprioritization-frame title="HTTP/2 PRIORITY_UPDATE Frame Payload"}
+
+The PRIORITY_UPDATE frame in HTTP/2 MUST NOT be sent prior to opening the
+stream.
 
 TODO: add more description of how to handle things like receiving
 PRIORITY_UPDATE on wrong stream, a PRIORITY_UPDATE with an invalid ID, etc.
@@ -468,6 +472,17 @@ Element ID is interpreted as a Push ID.
 
 Empty:
 : A seven-bit field that has no semantic value.
+
+The PRIORITY_UPDATE frame in HTTP/3 MUST NOT be sent before the stream
+has been opened or a PUSH_PROMISE for the corresponding PUSH_ID has been
+received.
+
+In HTTP/3, the PRIORITY_UPDATE frame can arrive before any data is received
+on the corresponding stream or server push due to reordering or proactively
+changing the priority of a server push.  If the stream ID is one which can
+be opened, the frame SHOULD be buffered until the stream is opened and
+applied immediately after the HEADERS are parsed.  This consumes extra state
+on the peer, but existing stream limits bound the size of that state.
 
 TODO: add more description of how to handle things like receiving
 PRIORITY_UPDATE on wrong stream, a PRIORITY_UPDATE with an invalid ID, etc.

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -435,7 +435,7 @@ frame header MUST be zero (0x0).
 ~~~
 {: #fig-h2-reprioritization-frame title="HTTP/2 PRIORITY_UPDATE Frame Payload"}
 
-The PRIORITY_UPDATE frame in HTTP/2 MUST NOT be sent prior to opening the
+The HTTP/2 PRIORITY_UPDATE frame MUST NOT be sent prior to opening the
 stream.
 
 TODO: add more description of how to handle things like receiving

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -478,16 +478,9 @@ The HTTP/3 PRIORITY_UPDATE frame MUST NOT be sent with an invalid identifier,
 including before the request stream has been opened or before a promised
 request has been received.
 
-In HTTP/3, the PRIORITY_UPDATE frame can arrive before any data is received
-on the corresponding stream or server push due to reordering or proactively
-changing the priority of a server push.  If the stream ID is one which can
-be opened, the frame SHOULD be buffered until the stream is opened and
-applied immediately after the HEADERS are parsed.  This consumes extra state
-on the peer, but existing stream limits bound the size of that state.
-
-The HTTP/3 PRIORITY_UPDATE frame is sent on the control stream. Because there
-are no ordering guarantees between streams, a client that reprioritizes a
-request before receiving the response data might cause the server to receive
+Because the HTTP/3 PRIORITY_UPDATE frame is sent on the control stream and
+there are no ordering guarantees between streams, a client that reprioritizes
+a request before receiving the response data might cause the server to receive
 a PRIORITY_UPDATE for an unknown request. If the request stream ID is within
 bidirectional stream limits, the PRIORITY_UPDATE frame SHOULD be buffered
 until the stream is opened and applied immediately after the request message

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -406,7 +406,7 @@ target of the reprioritization based on a version-specific identifier; in
 HTTP/2 this is the Stream ID, in HTTP/3 this is either the Stream ID or Push ID.
 
 In HTTP/2 and HTTP/3, after a request message is sent on a stream, the stream
-transitions it into a state that prevents the client from sending additional
+transitions to a state that prevents the client from sending additional
 frames on the stream. Modifying this behavior would require a semantic change
 to the protocol, but this is avoided by restricting the stream on which a
 PRIORITY_UPDATE frame can be sent. In HTTP/2 the frame is on stream zero and

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -437,7 +437,7 @@ frame header MUST be zero (0x0).
 
 The HTTP/2 PRIORITY_UPDATE frame MUST NOT be sent prior to opening the
 stream.  If a PRIORITY_UPDATE is received prior to the stream being opened,
-it MAY close the connection error.
+it MAY be treated as a connection error of type PROTOCOL_ERROR.
 
 TODO: add more description of how to handle things like receiving
 PRIORITY_UPDATE on wrong stream, a PRIORITY_UPDATE with an invalid ID, etc.

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -473,7 +473,7 @@ Element ID is interpreted as a Push ID.
 Empty:
 : A seven-bit field that has no semantic value.
 
-The PRIORITY_UPDATE frame in HTTP/3 MUST NOT be sent before the stream
+The HTTP/3 PRIORITY_UPDATE frame MUST NOT be sent with an invalid identifier including before the request stream
 has been opened or a PUSH_PROMISE for the corresponding PUSH_ID has been
 received.
 


### PR DESCRIPTION
And what to do if it's received out of order in HTTP/3.

I was going to file an issue, but instead this PR sticks with existing behavior, and tightens up the constraints some.