### PR TITLE
Replace priority scheme negotiation

### DIFF
--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -141,7 +141,7 @@ complex HTTP/2 setups seen in practice, at least for the web use case.
 
 The problems and insights set out above are motivation for allowing endpoints to
 opt out of using the HTTP/2 priority scheme, in favor of using an alternative
-such as the scheme defined in this specification. Endpoints would benefit from
+such as the scheme defined in this specification. Endpoints benefit from
 understanding their peer's intention, so the new
 SETTINGS_DEPRECATE_HTTP2_PRIORITIES is defined. The value of the parameter MUST
 be 0 or 1.

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -519,7 +519,7 @@ In order to mitigate this fairness problem, when a server responds to a request
 that is known to have come through an intermediary, the server SHOULD prioritize
 the response as if it was assigned the priority of  `u=1, i=?1`
 (i.e. round-robin) regardless of the value of the Priority header field being
-transmitted, unless the server has the knowledge that no intermediaries are
+transmitted, unless the server knows the intermediary is not
 coalescing requests from multiple clients.
 
 A server can determine if a request came from an intermediary through

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -137,19 +137,21 @@ multiple experiments from independent research have shown that simpler schemes
 can reach at least equivalent performance characteristics compared to the more
 complex HTTP/2 setups seen in practice, at least for the web use case.
 
-## Disabling HTTP/2 Priorities {#settings-this-scheme}
+## Disabling HTTP/2 Priorities
 The problems and insights set out above are motivation for allowing endpoints to
 opt out of using the HTTP/2 priority scheme. Endpoints would benefit from
 understanding their peer's intention, so the new
 SETTINGS_DISABLE_HTTP2_PRIORITIES is defined. The value of the parameter MUST be
 0 or 1.
 
-If either side sends the parameter with a value of `1`, clients SHOULD NOT send
-the HTTP/2 priority signal in HEADERS or PRIORITY frames. If both sides send the
-parameter with a value of `0`, then both parties MAY use HTTP/2 priorities as
-they see fit. A sender MUST NOT send the parameter with the value of `1` after
-previously sending a value of `0`. If a client or server does not send the
-setting, the peer SHOULD assume that HTTP/2 priority signals are interpreted.
+An HTTP/2 client SHOULD use the HTTP/2 priority scheme (as it sees fit) until it
+receives the peer's SETTINGS_DISABLE_HTTP2_PRIORITIES settings with the value of
+`1`. As the SETTINGS frame precedes any priority signal sent from a client, a server can
+determine if it should respect the HTTP/2 scheme before building state.
+
+A client that disables the HTTP/2 priority scheme SHOULD subtitute it with some
+other means of signaling request priority. The scheme extensible priority scheme
+is RECOMMENDED.
 
 # Priority Parameters
 
@@ -503,9 +505,7 @@ that is known to have come through an intermediary, the server SHOULD prioritize
 the response as if it was assigned the priority of  `u=1, i=?1`
 (i.e. round-robin) regardless of the value of the Priority header field being
 transmitted, unless the server has the knowledge that no intermediaries are
-coalescing requests from multiple clients. That can be determined by the
-settings when the intermediaries support this specification (see
-{{settings-this-scheme}}), or else through configuration.
+coalescing requests from multiple clients.
 
 A server can determine if a request came from an intermediary through
 configuration, or by consulting if that request contains one of the following

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -154,7 +154,7 @@ SETTINGS_DEPRECATE_HTTP2_PRIORITIES parameter with the value of 1.
 
 A sender MUST NOT change the SETTINGS_DEPRECATE_HTTP2_PRIORITIES parameter value
 after the first SETTINGS frame. Detection of a change by a receiver MUST be
-treated as a connection error of type PROTOCOL_ERROR. 
+treated as a connection error of type PROTOCOL_ERROR.
 
 Until the client receives the SETTINGS frame from the server, the client SHOULD
 send both the priority signal defined in the HTTP/2 priority scheme (as it sees
@@ -708,7 +708,7 @@ Roy Fielding presented the idea of using a header field for representing
 priorities in <http://tools.ietf.org/agenda/83/slides/slides-83-httpbis-5.pdf>.
 In <https://github.com/pmeenan/http3-prioritization-proposal>, Patrick Meenan
 advocates for representing the priorities using a tuple of urgency and
-concurrency. The ability to disable HTTP/2 priortization is based on
+concurrency. The ability to deprecate HTTP/2 priortization is based on
 {{?I-D.lassey-priority-setting}}, authored by Brad Lassey and Lucas Pardue, with
 modifications based on feedback that was not incorporated into an update to that
 document.
@@ -728,7 +728,7 @@ Mike Bishop, Roberto Peon, Robin Marx, Roy Fielding.
 ## Since draft-kazuho-httpbis-priority-03
 
 * Changed numbering from [-1,6] to [0,7] (#78)
-* Replaced priority scheme negotiation with HTTP/2 priority disabling (#100)
+* Replaced priority scheme negotiation with HTTP/2 priority deprecation (#100)
 * Shorten parameter names (#108)
 * Expand on considerations (#105, #107, #109, #110, #111, #113)
 

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -138,16 +138,18 @@ can reach at least equivalent performance characteristics compared to the more
 complex HTTP/2 setups seen in practice, at least for the web use case.
 
 ## Disabling HTTP/2 Priorities
+
 The problems and insights set out above are motivation for allowing endpoints to
 opt out of using the HTTP/2 priority scheme. Endpoints would benefit from
 understanding their peer's intention, so the new
-SETTINGS_DISABLE_HTTP2_PRIORITIES is defined. The value of the parameter MUST be
-0 or 1.
+SETTINGS_DEPRECATE_HTTP2_PRIORITIES is defined. The value of the parameter MUST
+be 0 or 1.
 
 An HTTP/2 client SHOULD use the HTTP/2 priority scheme (as it sees fit) until it
-receives the peer's SETTINGS_DISABLE_HTTP2_PRIORITIES settings with the value of
-`1`. As the SETTINGS frame precedes any priority signal sent from a client, a server can
-determine if it should respect the HTTP/2 scheme before building state.
+receives the peer's SETTINGS_DEPRECATE_HTTP2_PRIORITIES settings with the value
+of `1`. As the SETTINGS frame precedes any priority signal sent from a client, a
+server can determine if it should respect the HTTP/2 scheme before building
+state.
 
 A client that disables the HTTP/2 priority scheme SHOULD subtitute it with some
 other means of signaling request priority. The scheme extensible priority scheme
@@ -650,7 +652,7 @@ This specification registers the following entry in the HTTP/2 Settings registry
 established by {{!RFC7540}}:
 
 Name:
-: SETTINGS_DISABLE_HTTP2_PRIORITIES
+: SETTINGS_DEPRECATE_HTTP2_PRIORITIES
 
 Code:
 : 0x9

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -148,13 +148,13 @@ be 0 or 1. Any value other than 0 or 1 MUST be treated as a connection error
 (see {{!RFC7540}}; Section 5.4.1) of type PROTOCOL_ERROR.
 
 Endpoints MUST send this SETTINGS parameter as part of the first SETTINGS frame.
-When the peer receives the first SETTINGS frame, it learns if the sender has
-deprecated the HTTP/2 priority scheme, by consulting the value of
-SETTINGS_DEPRECATE_HTTP2_PRIORITIES parameter (or through lack of that
-parameter).
+When the peer receives the first SETTINGS frame, it learns the sender has
+deprecated the HTTP/2 priority scheme if it receives the
+SETTINGS_DEPRECATE_HTTP2_PRIORITIES parameter with the value of 1.
 
-A sender MUST NOT change the SETTINGS_DEPRECATE_HTTP2_PRIORITIES parameter
-value after the first SETTINGS frame.
+A sender MUST NOT change the SETTINGS_DEPRECATE_HTTP2_PRIORITIES parameter value
+after the first SETTINGS frame. Detection of a change by a receiver MUST be
+treated as a connection error of type PROTOCOL_ERROR. 
 
 Until the client receives the SETTINGS frame from the server, the client SHOULD
 send both the priority signal defined in the HTTP/2 priority scheme (as it sees

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -146,11 +146,14 @@ understanding their peer's intention, so the new
 SETTINGS_DEPRECATE_HTTP2_PRIORITIES is defined. The value of the parameter MUST
 be 0 or 1.
 
-Enpoints MUST send this SETTINGS parameter as part of the first SETTINGS frame.
+Endpoints MUST send this SETTINGS parameter as part of the first SETTINGS frame.
 When the peer receives the first SETTINGS frame, it learns if the sender has
 deprecated the HTTP/2 priority scheme, by consulting the value of
 SETTINGS_DEPRECATE_HTTP2_PRIORITIES parameter (or through lack of that
 parameter).
+
+A sender MUST NOT change the SETTINGS_DEPRECATE_HTTP2_PRIORITIES parameter
+value after the first SETTINGS frame.
 
 Until the client receives the SETTINGS frame from the server, the client SHOULD
 send both the priority signal defined in the HTTP/2 priority scheme (as it sees

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -140,7 +140,8 @@ complex HTTP/2 setups seen in practice, at least for the web use case.
 ## Disabling HTTP/2 Priorities
 
 The problems and insights set out above are motivation for allowing endpoints to
-opt out of using the HTTP/2 priority scheme. Endpoints would benefit from
+opt out of using the HTTP/2 priority scheme, in favor of using an alternative
+such as the scheme defined in this specification. Endpoints would benefit from
 understanding their peer's intention, so the new
 SETTINGS_DEPRECATE_HTTP2_PRIORITIES is defined. The value of the parameter MUST
 be 0 or 1.

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -145,15 +145,23 @@ understanding their peer's intention, so the new
 SETTINGS_DEPRECATE_HTTP2_PRIORITIES is defined. The value of the parameter MUST
 be 0 or 1.
 
-An HTTP/2 client SHOULD use the HTTP/2 priority scheme (as it sees fit) until it
-receives the peer's SETTINGS_DEPRECATE_HTTP2_PRIORITIES settings with the value
-of `1`. As the SETTINGS frame precedes any priority signal sent from a client, a
-server can determine if it should respect the HTTP/2 scheme before building
-state.
+Enpoints MUST send this SETTINGS parameter as part of the first SETTINGS frame.
+When the peer receives the first SETTINGS frame, it learns if the sender has
+deprecated the HTTP/2 priority scheme, by consulting the value of
+SETTINGS_DEPRECATE_HTTP2_PRIORITIES parameter (or through lack of that
+parameter).
 
-A client that disables the HTTP/2 priority scheme SHOULD subtitute it with some
-other means of signaling request priority. The scheme extensible priority scheme
-is RECOMMENDED.
+Until the client receives the SETTINGS frame from the server, the client SHOULD
+send both the priority signal defined in the HTTP/2 priority scheme (as it sees
+fit) and also that of this prioritization scheme. Once the client learns that
+the HTTP/2 priority scheme is deprecated, it SHOULD stop sending the HTTP/2
+priority signals. If the client learns that the HTTP/2 priority scheme is not
+deprecated, it SHOULD stop sending PRIORITY_UPDATE frames, but MAY continue
+sending the Priority header field, as it is an end-to-end signal that might be
+useful to nodes behind the server that the client is directly connected to.
+
+As the SETTINGS frame precedes any priority signal sent from a client, a server
+can determine if it should respect the HTTP/2 scheme before building state.
 
 # Priority Parameters
 

--- a/draft-kazuho-httpbis-priority.md
+++ b/draft-kazuho-httpbis-priority.md
@@ -144,7 +144,8 @@ opt out of using the HTTP/2 priority scheme, in favor of using an alternative
 such as the scheme defined in this specification. Endpoints benefit from
 understanding their peer's intention, so the new
 SETTINGS_DEPRECATE_HTTP2_PRIORITIES is defined. The value of the parameter MUST
-be 0 or 1.
+be 0 or 1. Any value other than 0 or 1 MUST be treated as a connection error
+(see {{!RFC7540}}; Section 5.4.1) of type PROTOCOL_ERROR.
 
 Endpoints MUST send this SETTINGS parameter as part of the first SETTINGS frame.
 When the peer receives the first SETTINGS frame, it learns if the sender has


### PR DESCRIPTION
I *think* this resolves #100.

The change removes the SETTINGS-based negotiation, and replaces it with a way to disable the HTTP/2 tree. I borrowed the text from draft-lassey 00 but inverted it from `ENABLE` to `DISABLE` and incorporated some minor feedback that was received on the HTTP list after Montreal.

If I have misunsertood #100 I can change thing a bit.

@kazuho I left a fragment in the coalescing section that I am unsure if it needs to be removed or modified - please advise

> unless the server has the knowledge that no intermediaries are
coalescing requests from multiple clients. That can be determined by the
settings when the intermediaries support this specification (see
{{settings-this-scheme}}), or else through configuration.